### PR TITLE
Send email to customer store ID

### DIFF
--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -359,7 +359,7 @@ class Data extends AbstractData
      */
     public function emailApprovalAction($customer, $emailType)
     {
-        $storeId = $this->getStoreId();
+        $storeId = $customer->getStoreId();
         $sendTo = $customer->getEmail();
         $sender = $this->getSenderCustomer();
         if ($this->getAutoApproveConfig()) {


### PR DESCRIPTION
The current approval mails in the backend get sent with storeId = 0. The customer needs an email with the correct storeID