### PR TITLE
Admin notification when auto approval and notify admin enabled not working

### DIFF
--- a/Plugin/CustomerCreatePost.php
+++ b/Plugin/CustomerCreatePost.php
@@ -137,6 +137,8 @@ class CustomerCreatePost
             if ($this->helperData->getAutoApproveConfig()) {
                 // case allow auto approve
                 $this->helperData->approvalCustomerById($customerId, TypeAction::OTHER);
+                // send email notify to admin
+                $this->helperData->emailNotifyAdmin($customer);
                 // send email approve to customer
                 $this->helperData->emailApprovalAction($customer, 'approve');
             } else {


### PR DESCRIPTION
The logic in the CustomerCreate post plugin does not notify admin by email when auto approval is enabled AND notify admin is enabled.